### PR TITLE
oci-umount: do not error out if the config file is missing

### DIFF
--- a/src/oci-umount.c
+++ b/src/oci-umount.c
@@ -114,6 +114,7 @@ DEFINE_CLEANUP_FUNC(yajl_val, yajl_tree_free)
 
 #define pr_perror(fmt, ...) syslog(LOG_ERR, "umounthook <error>: " fmt ": %m\n", ##__VA_ARGS__)
 #define pr_pinfo(fmt, ...) syslog(LOG_INFO, "umounthook <info>: " fmt "\n", ##__VA_ARGS__)
+#define pr_pwarning(fmt, ...) syslog(LOG_INFO, "umounthook <warning>: " fmt "\n", ##__VA_ARGS__)
 #define pr_pdebug(fmt, ...) syslog(LOG_DEBUG, "umounthook <debug>: " fmt "\n", ##__VA_ARGS__)
 
 #define BUFLEN 1024
@@ -307,6 +308,10 @@ static int prestart(const char *rootfs,
 	 * paths which are not a mountpoint on host */
 	fp = fopen(MOUNTCONF, "r");
 	if (fp == NULL) {
+		if (errno == ENOENT) {
+			pr_pwarning("Config file not found: %s", MOUNTCONF);
+			return 0;
+		}
 		pr_perror("Failed to open config file: %s", MOUNTCONF);
 		return EXIT_FAILURE;
 	}


### PR DESCRIPTION
When the configuration file is missing, just raise a warning instead of
giving an error.

Closes: https://github.com/rhatdan/oci-umount/issues/2

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>