### PR TITLE
Get Bundle Path out of config.json

### DIFF
--- a/oci-umount.conf
+++ b/oci-umount.conf
@@ -6,3 +6,6 @@
 /var/lib/docker-latest/overlay
 /var/lib/docker-latest/devicemapper
 /var/lib/docker-latest/containers
+/var/lib/container/storage/lvm
+/var/lib/container/storage/devicemapper
+/var/lib/container/storage/overlay


### PR DESCRIPTION
When oci-umount is called by cri-o it will not have the root path,
this should be retrieved from the bundle path config.json

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>