### PR TITLE
Set %config for oci-umount.conf, update commit-ish

### DIFF
--- a/oci-umount.spec
+++ b/oci-umount.spec
@@ -2,10 +2,10 @@
 %global provider_tld    com
 %global project         projectatomic
 %global repo            oci-umount
-# https://github.com/projectatomic/oci-register-machine
+# https://github.com/projectatomic/oci-umount
 %global provider_prefix %{provider}.%{provider_tld}/%{project}/%{repo}
 %global import_path     %{provider_prefix}
-%global commit          de345df3c18a6abfc8d9cf3822405c0e1bbe65c9
+%global commit          c1345751d063d298f4d38c0ceb661c462f0963a3
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 
 Name:           oci-umount
@@ -46,6 +46,7 @@ make %{?_smp_mflags}
 %{_mandir}/man1/oci-umount.1*
 %doc README.md
 %license LICENSE
+%config(noreplace) %{_sysconfdir}/oci-umount.conf
 %dir /%{_libexecdir}/oci
 %dir /%{_libexecdir}/oci/hooks.d
 


### PR DESCRIPTION
The changes in this diff allows for a successful creation of an RPM
package:

```
13:24:06 csos-builder ~ # rpmbuild -ba rpmbuild/SPECS/oci-umount.spec 2>&1 | tail
Checking for unpackaged file(s): /usr/lib/rpm/check-files /root/rpmbuild/BUILDROOT/oci-umount-0.1-1.gitc134575.el7.csos.x86_64
Wrote: /root/rpmbuild/SRPMS/oci-umount-0.1-1.gitc134575.el7.csos.src.rpm
Wrote: /root/rpmbuild/RPMS/x86_64/oci-umount-0.1-1.gitc134575.el7.csos.x86_64.rpm
Wrote: /root/rpmbuild/RPMS/x86_64/oci-umount-debuginfo-0.1-1.gitc134575.el7.csos.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.lQTKzb
+ umask 022
+ cd /root/rpmbuild/BUILD
+ cd oci-umount-c1345751d063d298f4d38c0ceb661c462f0963a3
+ /usr/bin/rm -rf /root/rpmbuild/BUILDROOT/oci-umount-0.1-1.gitc134575.el7.csos.x86_64
+ exit 0
```