### PR TITLE
Allow container definitions where rootfs is not an absolute path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([OCI Systemd Hook], 0.1.4)
+AC_INIT([OCI Umount], 0.1.10)
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror subdir-objects])


### PR DESCRIPTION
Patch copied from https://github.com/projectatomic/oci-systemd-hook/pull/67

From Jason Wessel

In earlier versions of the runc frame work the rootfs path was passed
as a key with the initial json that was passed on the stdin and it was
automatically computed to be an absolute path.

This translation to an absolute path must be done in the hook based on
the bundlePath. This allows the config.json to be relocated by the
container hosting system storage without modifying the config.json.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>