### PR TITLE
Return early if there is nothing to unmount

### DIFF
--- a/src/oci-umount.c
+++ b/src/oci-umount.c
@@ -372,6 +372,9 @@ static int prestart(const char *rootfs,
 		mounts_on_host[nr_umounts++] = real_path;
 	}
 
+	if (!nr_umounts)
+		return 0;
+
 	snprintf(process_mnt_ns_fd, PATH_MAX, "/proc/%d/ns/mnt", pid);
 
 	fd = open(process_mnt_ns_fd, O_RDONLY);


### PR DESCRIPTION
It is possible that /etc/oci-umount.conf is empty and there is nothing to
unmount. In such cases return early and there is no need to enter process
mount namespace, parse mountinfo etc.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>