### PR TITLE
Don't umount path that end in "/"

### DIFF
--- a/oci-umount.conf
+++ b/oci-umount.conf
@@ -1,7 +1,11 @@
+# oci-umount will unmount all mount points mounted on within the specified
+# path.  If the path ends with the "/" oci-umount will only umount the mount
+# points mounted under the path.  If there is a mount point on the path itself,
+# oci-umount will not unount it.
 /var/lib/docker/overlay2
 /var/lib/docker/overlay
 /var/lib/docker/devicemapper
-/var/lib/docker/containers
+/var/lib/docker/containers/
 /var/lib/docker-latest/overlay2
 /var/lib/docker-latest/overlay
 /var/lib/docker-latest/devicemapper


### PR DESCRIPTION
If the path in the configuration file ends in a "/", then
we should not umount the matchping path, but only subpaths under
that path.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>