### PR TITLE
Add capability to unmount submounts of a mount point on host

### DIFF
--- a/oci-umount.conf
+++ b/oci-umount.conf
@@ -1,11 +1,17 @@
+# This contains a list of paths on host which will be unmounted inside
+# container. (If they are mounted inside container).
+
+# If there is a "/*" at the end, that means only mounts underneath that
+# mounts (submounts) will be unmounted but top level mount will remain
+# in place.
 /var/lib/docker/overlay2
 /var/lib/docker/overlay
 /var/lib/docker/devicemapper
-/var/lib/docker/containers
+/var/lib/docker/containers/*
 /var/lib/docker-latest/overlay2
 /var/lib/docker-latest/overlay
 /var/lib/docker-latest/devicemapper
-/var/lib/docker-latest/containers
+/var/lib/docker-latest/containers/*
 /var/lib/container/storage/lvm
 /var/lib/container/storage/devicemapper
 /var/lib/container/storage/overlay

--- a/src/oci-umount.c
+++ b/src/oci-umount.c
@@ -32,6 +32,8 @@
 /* Basic mount info. For now we need only destination */
 struct mount_info {
 	char *destination;
+	unsigned mntid;
+	unsigned parent_mntid;
 };
 
 /* Basic config mount info */
@@ -190,10 +192,16 @@ static int parse_mountinfo(struct mount_info **info, size_t *sz)
 	while ((getline(&line, &len, fp)) != -1) {
 		char *token, *str = line, *dest;
 		int token_idx = 0;
+		unsigned mntid, parent_mntid;
 
+		mntid = parent_mntid = 0;
 		while ((token = strtok(str, " ")) != NULL) {
 			str = NULL;
 			token_idx++;
+			if (token_idx == 1)
+				mntid = atoi(token);
+			if (token_idx == 2)
+				parent_mntid = atoi(token);
 			if (token_idx != 5)
 			       continue;
 
@@ -203,7 +211,10 @@ static int parse_mountinfo(struct mount_info **info, size_t *sz)
 				return -1;
 			}
 
-			mnt_table[table_idx++].destination = dest;
+			mnt_table[table_idx].destination = dest;
+			mnt_table[table_idx].mntid = mntid;
+			mnt_table[table_idx].parent_mntid = parent_mntid;
+			table_idx++;
 			if (table_idx == nr_elem) {
 				int new_sz_bytes = table_sz_bytes + elem_sz * 64;
 				mnt_table_temp = grow_mountinfo_table(mnt_table, table_sz_bytes, new_sz_bytes);


### PR DESCRIPTION
Right now /etc/oci-umount.conf contains path of mount points on host which get unmounted in container. There is a corner case where we don't want top level mount to be unmounted, instead want only submounts to go away.

This patch series adds that capability.