### PR TITLE
bump version number

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([OCI Umount], 0.1.10)
+AC_INIT([OCI Umount], 2.0.0)
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror subdir-objects])


### PR DESCRIPTION
Since we're gonna separate out oci-umount into its own independent
package, we need to make sure that rpm updates are smooth without
requiring an Epoch bump.

Currently, oci-umount is a subpackage of docker and its epoch:version
string can be anywhere from 2:1.12.6 on RHEL to 2:1.13.1 on Fedora.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>


@rhatdan @rhvgoyal PTAL