### PR TITLE
Fix containers/storage mount point names

### DIFF
--- a/oci-umount.conf
+++ b/oci-umount.conf
@@ -12,6 +12,7 @@
 /var/lib/docker-latest/overlay
 /var/lib/docker-latest/devicemapper
 /var/lib/docker-latest/containers/*
-/var/lib/container/storage/lvm
-/var/lib/container/storage/devicemapper
-/var/lib/container/storage/overlay
+/var/lib/containers/storage/lvm
+/var/lib/containers/storage/devicemapper
+/var/lib/containers/storage/overlay
+/var/run/containers/storage


### PR DESCRIPTION
Also add in /run/containers/storage as the place where shm is mounted.