### PR TITLE
Add oci-config.json file.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,6 +3,10 @@ oci_umount_SOURCES = src/oci-umount.c
 oci_umount_DATA = oci-umount.conf
 oci_umountdir=/etc
 
+oci_umount_json_CONFIG = oci-umount-json
+oci_umount_json_DATA = oci-umount.json
+oci_umount_jsondir=/usr/share/containers/oci/hooks.d
+
 oci_umount_CFLAGS = -Wall -Wextra -std=c99 $(YAJL_CFLAGS)
 oci_umount_LDADD = $(YAJL_LIBS)
 oci_umount_CFLAGS += $(SELINUX_CFLAGS)
@@ -14,12 +18,15 @@ EXTRA_DIST = README.md LICENSE
 oci-umount.1: doc/oci-umount.1.md
 	go-md2man -in doc/oci-umount.1.md -out oci-umount.1
 
-dist: oci-umount.spec 
+spec: oci-umount.spec
 	spectool -g oci-umount.spec
 
-rpm: dist
+rpm: spec
 	rpmbuild --define "_sourcedir `pwd`" --define "_specdir `pwd`" \
 	--define "_rpmdir `pwd`" --define "_srcrpmdir `pwd`" -ba oci-umount.spec 
+
+install-data-local:
+	$(MKDIR_P) $(DESTDIR)/etc/containers/oci/hooks.d
 
 clean-local:
 	-rm -f oci-umount.1 *~

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([OCI Umount], 2.0.0)
+AC_INIT([OCI Umount], 2.1.0)
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror subdir-objects])

--- a/oci-umount.json
+++ b/oci-umount.json
@@ -1,0 +1,5 @@
+{
+    "hasbindmounts": true,
+    "hook": "/usr/libexec/oci/hooks.d/oci-umount",
+    "stages": [ "prestart" ]
+}

--- a/oci-umount.spec
+++ b/oci-umount.spec
@@ -5,11 +5,11 @@
 # https://github.com/projectatomic/oci-umount
 %global provider_prefix %{provider}.%{provider_tld}/%{project}/%{repo}
 %global import_path     %{provider_prefix}
-%global commit          c1345751d063d298f4d38c0ceb661c462f0963a3
+%global commit          f034b5a7a33ae8496774d8747edc0ba370a6bcb1
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 
 Name:           oci-umount
-Version:        0.1
+Version:        2.1
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        OCI umount hook for docker
 Group:          Applications/Text
@@ -49,7 +49,13 @@ make %{?_smp_mflags}
 %config(noreplace) %{_sysconfdir}/oci-umount.conf
 %dir /%{_libexecdir}/oci
 %dir /%{_libexecdir}/oci/hooks.d
+%dir /%{_sysconfdir}/containers/oci/hooks.d
+%dir /usr/share/containers/oci/hooks.d
+/usr/share/containers/oci/hooks.d/oci-umount.json
 
 %changelog
+* Wed Aug 16 2017 Dan Walsh <dwalsh@redhat.com> - 2.1.1
+- Add support for /usr/share/containers/oci/hooks.d json files
+
 * Wed May 17 2017 Dan Walsh <dwalsh@redhat.com> - 0.1.1
 - Initial RPM release


### PR DESCRIPTION
CRI-O has defined a new config file for hooks.  Basically this config
file test OCI when to run a hook. We only want to run the oci-umount
hook when the container has bind mounts and only want to run it during
the prestart phase.  This config specifies these times.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>