### PR TITLE
Add support for reading /etc/umount.d rather then /etc/umount.conf

### DIFF
--- a/oci-umount.conf
+++ b/oci-umount.conf
@@ -12,7 +12,3 @@
 /var/lib/docker-latest/overlay
 /var/lib/docker-latest/devicemapper
 /var/lib/docker-latest/containers/*
-/var/lib/containers/storage/lvm
-/var/lib/containers/storage/devicemapper
-/var/lib/containers/storage/overlay
-/var/run/containers/storage

--- a/oci-umount.spec
+++ b/oci-umount.spec
@@ -52,6 +52,9 @@ make %{?_smp_mflags}
 %dir /%{_sysconfdir}/containers/oci/hooks.d
 %dir /usr/share/containers/oci/hooks.d
 /usr/share/containers/oci/hooks.d/oci-umount.json
+/usr/share/oci-umount/oci-umount.d
+%ghost /etc/oci-umount/oci-umount.d
+
 
 %changelog
 * Wed Aug 16 2017 Dan Walsh <dwalsh@redhat.com> - 2.1.1

--- a/src/oci-umount.c
+++ b/src/oci-umount.c
@@ -746,9 +746,9 @@ static int parseBundle(const char *id, yajl_val *node_ptr, char **rootfs, struct
 	config_node = yajl_tree_parse((const char *)configData, errbuf, sizeof(errbuf));
 	if (config_node == NULL) {
 		if (strlen(errbuf)) {
-			pr_perror("parse error: %s: %s: %s", id, config_file_name, errbuf);
+			pr_perror("%s: parse error: %s: %s", id, config_file_name, errbuf);
 		} else {
-			pr_perror("parse error: %s: %s: unknown error", id, config_file_name);
+			pr_perror("%s: parse error: %s: unknown error", id, config_file_name);
 		}
 		return EXIT_FAILURE;
 	}


### PR DESCRIPTION
We want to allow container runtimes to ship their own configuration files to specify which mount points they want to umount.  This will eliminate some of the noise in logs.
crio and docker should ship configuration specific to their configuration.