### PR TITLE
Don't check mountpoints if spec is for submounts only

### DIFF
--- a/oci-umount.conf
+++ b/oci-umount.conf
@@ -15,4 +15,4 @@
 /var/lib/containers/storage/lvm
 /var/lib/containers/storage/devicemapper
 /var/lib/containers/storage/overlay
-/var/run/containers/storage
+/var/run/containers/storage/*


### PR DESCRIPTION
When a user specifies that they want all mountpoint under a path
to be unmounted, there is not need for the path to be a mountpoint.