### PR TITLE
Drop libselinux dependency

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,8 +12,6 @@ oci_umount_optionsdir=/usr/share/oci-umount/
 
 oci_umount_CFLAGS = -Wall -Wextra -std=c99 $(YAJL_CFLAGS)
 oci_umount_LDADD = $(YAJL_LIBS)
-oci_umount_CFLAGS += $(SELINUX_CFLAGS)
-oci_umount_LDADD += $(SELINUX_LIBS)
 
 dist_man_MANS = oci-umount.1
 EXTRA_DIST = README.md LICENSE

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,6 @@ AC_USE_SYSTEM_EXTENSIONS
 AC_SYS_LARGEFILE
 
 PKG_CHECK_MODULES([YAJL], [yajl >= 2.0.0])
-PKG_CHECK_MODULES([SELINUX], [libselinux >= 2.0.0])
 PKG_CHECK_MODULES([LIBMOUNT], [mount >= 2.23.0])
 
 AC_MSG_CHECKING([whether to disable argument checking])

--- a/oci-umount.spec
+++ b/oci-umount.spec
@@ -27,7 +27,6 @@ BuildRequires:  gcc
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  pkgconfig(yajl)
-BuildRequires:  pkgconfig(libselinux)
 BuildRequires:  pkgconfig(mount)
 BuildRequires:  golang-github-cpuguy83-go-md2man
 BuildRequires:  pcre-devel

--- a/src/oci-umount.c
+++ b/src/oci-umount.c
@@ -16,7 +16,6 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <linux/limits.h>
-#include <selinux/selinux.h>
 #include <yajl/yajl_tree.h>
 #include <ctype.h>
 


### PR DESCRIPTION
The dependency initially landed in 4793dc7 which wiggled around in commits but ended up with a `selinux/selinux.h` import for `setfilecon`.  The `setfilecon` call was removed in ba8df559, which landed \#57 (when this was in some other repository?).  ba8df559 is a strange merge; it also differs from both of its parents in dropping `systemdhook.c` in favor of a much smaller `oci-umount.c`.  I expect the `selinux/selinux.h` import was just overlooked then.