### PR TITLE
oci-umount.conf: add CRI-O paths

### DIFF
--- a/oci-umount.conf
+++ b/oci-umount.conf
@@ -12,3 +12,6 @@
 /var/lib/docker-latest/overlay
 /var/lib/docker-latest/devicemapper
 /var/lib/docker-latest/containers/*
+/var/lib/containers/storage/*
+/run/containers/storage/*
+/var/lib/origin/*


### PR DESCRIPTION
We need a new package built for centos for this hook so we can install it on the crio sys container

@lsm5 @giuseppe @mrunalp @rhatdan 

Signed-off-by: Antonio Murdaca <runcom@redhat.com>