### PR TITLE
Use Janssson API instead of YAJL

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,8 +10,8 @@ oci_umount_jsondir=/usr/share/containers/oci/hooks.d
 oci_umount_options_DATA = oci-umount-options.conf
 oci_umount_optionsdir=/usr/share/oci-umount/
 
-oci_umount_CFLAGS = -Wall -Wextra -std=c99 $(YAJL_CFLAGS)
-oci_umount_LDADD = $(YAJL_LIBS)
+oci_umount_CFLAGS = -Wall -Wextra -std=c99 $(JANSSON_CFLAGS)
+oci_umount_LDADD = $(JANSSON_LIBS)
 
 dist_man_MANS = oci-umount.1
 EXTRA_DIST = README.md LICENSE

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AM_PROG_CC_C_O
 AC_USE_SYSTEM_EXTENSIONS
 AC_SYS_LARGEFILE
 
-PKG_CHECK_MODULES([YAJL], [yajl >= 2.0.0])
+PKG_CHECK_MODULES([JANSSON], [jansson >= 2.10])
 PKG_CHECK_MODULES([LIBMOUNT], [mount >= 2.23.0])
 
 AC_MSG_CHECKING([whether to disable argument checking])


### PR DESCRIPTION
YAJL upstream has been pretty much dead for a while now.
I used commit bd1c5c9 in libguestfs source for reference.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

modified:   Makefile.am
modified:   configure.ac
modified:   src/oci-umount.c

@rhvgoyal @rhatdan docker [run,exec,commit,push] work fine with this. PTAL.